### PR TITLE
kola/testiso: fix pxe-*.rootfs-appended test on s390x

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -106,8 +106,7 @@ var (
 		"iso-offline-install.s390fw",
 		"iso-offline-install.mpath.s390fw",
 		"iso-offline-install.4k.s390fw",
-		// FIXME: https://github.com/coreos/fedora-coreos-tracker/issues/1883
-		//"pxe-online-install.rootfs-appended.s390fw",
+		"pxe-online-install.rootfs-appended.s390fw",
 		"pxe-offline-install.s390fw",
 		"miniso-install.s390fw",
 		"miniso-install.nm.s390fw",

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -418,8 +418,8 @@ func (t *installerRun) completePxeSetup(kargs []string) error {
 		// this is only for s390x where the pxe image has to be created;
 		// s390 doesn't seem to have a pre-created pxe image although have to check on this
 		if t.pxe.pxeimagepath == "" {
-			kernelpath := filepath.Join(t.builddir, t.kern.kernel)
-			initrdpath := filepath.Join(t.builddir, t.kern.initramfs)
+			kernelpath := filepath.Join(t.tftpdir, t.kern.kernel)
+			initrdpath := filepath.Join(t.tftpdir, t.kern.initramfs)
 			err := exec.Command("/usr/bin/mk-s390image", kernelpath, "-r", initrdpath,
 				"-p", filepath.Join(pxeconfigdir, "default"), filepath.Join(t.tftpdir, pxeimages[0])).Run()
 			if err != nil {


### PR DESCRIPTION
On s390x, `mk-s390image` is used to create a bootable `pxelinux.0` image from the live-kernel, live-initramfs, and cmdline. Because the cmdline doesn't include `coreos.liveiso`, systemd starts the `coreos-livepxe-rootfs.service`, which checks for the presence of the `coreos.live.rootfs_url` karg or the `/etc/coreos-live-rootfs` file, but neither is present. At the same time, `kola` generates a concatenated initramfs. This PR uses that initramfs as input for `mk-s390image`.